### PR TITLE
fix: pass repository name from Action context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 0.0.4 (2025-02-07)
+## 0.0.5 (2025-02-07)
 ### Features
 - Initial prototype release

--- a/action.yml
+++ b/action.yml
@@ -32,3 +32,4 @@ runs:
     - ${{ inputs.draft }}
     - ${{ inputs.write_to_summary }}
     - ${{ inputs.dry_run }}
+    - ${{ github.repository }}

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ outputs:
     description: "Link to the created release"
 runs:
   using: "docker"
-  image: "docker://outoforbitdev/action-release-changelog:build--a44ab16"
+  image: "docker://outoforbitdev/action-release-changelog:build--a1e1b6d"
   args:
     - ${{ inputs.github_token }}
     - ${{ inputs.changelog_file }}

--- a/create_release.py
+++ b/create_release.py
@@ -31,26 +31,17 @@ def create_github_release(repo, tag_name, token, body=None, draft=True, prerelea
     }
     response = requests.post(url, json=data, headers=headers)
     return response.json()
-
-def get_repo_name():
-    try:
-        repo_url = subprocess.check_output(["git", "config", "--get", "remote.origin.url"], text=True).strip()
-        repo_name = repo_url.rstrip(".git").split(":")[-1].split("/")[-2:]
-        return "/".join(repo_name)
-    except subprocess.CalledProcessError:
-        return None
     
 def write_release_to_output(release_version, release_link):
     write_to_summary(f"## Release Created\n\n- [{release_version}]({release_link})\n\n")
 
-def release_version(github_token, changelog_file, draft, should_write_to_summary, dry_run):
+def release_version(github_token, changelog_file, draft, should_write_to_summary, dry_run, repo_name):
     first_version = find_first_changelog_version(changelog_file)
     if first_version[0] != "v":
         first_version = f"v{first_version}"
     print(f"First version found: {first_version}")
     
     if first_version:
-        repo_name = get_repo_name()
         if repo_name and not dry_run:
             release_response = create_github_release(repo_name, first_version, github_token, f"Release {first_version}", draft)
             print(release_response)
@@ -82,4 +73,5 @@ if __name__ == "__main__":
     draft = sys.argv[3]
     should_write_to_summary = sys.argv[4]
     dry_run = sys.argv[5]
-    release_version(github_token, changelog_file, draft, should_write_to_summary, dry_run)
+    repo_name = sys.argv[6]
+    release_version(github_token, changelog_file, draft, should_write_to_summary, dry_run, repo_name)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,4 +7,4 @@ write_to_summary=$4
 dry_run=$5
 repository=$6
 
-python create_release.py $github_token $changelog_file $draft $write_to_summary $dry_run, $repository
+python create_release.py $github_token $changelog_file $draft $write_to_summary $dry_run $repository

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,5 +5,6 @@ changelog_file=$2
 draft=$3
 write_to_summary=$4
 dry_run=$5
+repository=$6
 
-python create_release.py $github_token $changelog_file $draft $write_to_summary $dry_run
+python create_release.py $github_token $changelog_file $draft $write_to_summary $dry_run, $repository


### PR DESCRIPTION
## Summary

Get the repo name from the action context instead of programmatically in the python script