### PR TITLE
fix: get repository name as input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,3 +25,4 @@ jobs:
         id: create-release
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 0.0.5 (2025-02-07)
+## 0.0.6 (2025-02-07)
 ### Features
 - Initial prototype release

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   github_token:
     description: "GitHub token with permissions to create a release (content: write)"
     required: true
+  repository:
+    description: "The name of the repository to create the release in (e.g. outoforbitdev/action-release-changelog)"
+    required: true
   changelog_file:
     description: "Filepath of the changelog file"
     default: "./CHANGELOG.md"
@@ -32,4 +35,4 @@ runs:
     - ${{ inputs.draft }}
     - ${{ inputs.write_to_summary }}
     - ${{ inputs.dry_run }}
-    - ${{ github.repository }}
+    - ${{ inputs.repository }}


### PR DESCRIPTION
## Summary

Get the repository name as input from the consumer instead of trying to determine it at runtime.