### PR TITLE
ci: provide github token to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,5 +24,5 @@ jobs:
         uses: ./
         id: create-release
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 0.0.7 (2025-02-07)
+## 0.0.8 (2025-02-08)
 ### Features
 - Initial prototype release

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 A GitHub Action for creating a release from the most recent version in the changelog.
 
 <p>
-  <a href="https://github.com/outoforbitdev/action-release-changelog/actions?query=workflow%3ATest+branch%3Amaster">
+  <a href="https://github.com/outoforbitdev/action-release-changelog/actions?query=workflow%3ATest">
     <img alt="Test build states" src="https://github.com/outoforbitdev/action-release-changelog/workflows/Test/badge.svg">
   </a>
-  <a href="https://github.com/outoforbitdev/action-release-changelog/actions?query=workflow%3ATest+branch%3Amaster">
+  <a href="https://github.com/outoforbitdev/action-release-changelog/actions?query=workflow%3ARelease+branch%3Amaster">
     <img alt="Release build states" src="https://github.com/outoforbitdev/action-release-changelog/workflows/Release/badge.svg">
   </a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/outoforbitdev/action-release-changelog">


### PR DESCRIPTION
## Summary

The release workflow was failing because the github token input was not updated from `github_token` to `github-token`.