### PR TITLE
fix: use custom logic for checking if a release exists

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ outputs:
     description: "Link to the created release"
 runs:
   using: "docker"
-  image: "docker://outoforbitdev/action-release-changelog:build--dcc6450"
+  image: "docker://outoforbitdev/action-release-changelog:build--52f71f9"
   args:
     - ${{ inputs.github-token }}
     - ${{ inputs.changelog-file }}

--- a/src/create_release.py
+++ b/src/create_release.py
@@ -80,10 +80,13 @@ def create_github_release(repo: Repository, tag_name: str, body: str="", draft: 
     return release
 
 def release_exists(repo, tag_name):
-    if repo.get_releases().totalCount == 0:
-        return False
-    release = repo.get_release(tag_name)
-    return release is not None
+    releases = repo.get_releases()
+    for release in releases:
+        if release.tag_name == tag_name:
+            if release.draft:
+                return None
+            return release
+    return None
     
 def write_release_to_summary(release_version, release_link):
     write_to_summary(f"## Release Created\n\n- [{release_version}]({release_link})\n\n")

--- a/src/create_release.py
+++ b/src/create_release.py
@@ -82,11 +82,9 @@ def create_github_release(repo: Repository, tag_name: str, body: str="", draft: 
 def release_exists(repo, tag_name):
     releases = repo.get_releases()
     for release in releases:
-        if release.tag_name == tag_name:
-            if release.draft:
-                return None
-            return release
-    return None
+        if release.tag_name == tag_name and not release.draft:
+            return True
+    return False
     
 def write_release_to_summary(release_version, release_link):
     write_to_summary(f"## Release Created\n\n- [{release_version}]({release_link})\n\n")


### PR DESCRIPTION
## Summary

`PyGithub` is opinionated about raising exceptions if a release doesn't exist, and classifies prereleases as non-existent. This implements custom logic for determining whether a release exists by pulling all the releases and checking each one. It will ignore draft releases. If the release being searched for does not exist, we return `None`.

## Test Plan

Updated unit tests.