### PR TITLE
ci: remove release path condition and streamline tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,6 @@ on:
       - beta
       - dev
       - staging
-    paths:
-      - CHANGELOG.md
 jobs:
   release:
     permissions: 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,6 @@ jobs:
   test-action:
     runs-on: ubuntu-latest
     name: Test Action
-    outputs:
-      new-release: ${{ steps.create-release.outputs.version-long != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -59,7 +57,6 @@ jobs:
       - test-python-script
       - test-docker-image
       - test-action
-    if: ${{ needs.test-action.outputs.new-release }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ jobs:
   test-docker-image:
     runs-on: ubuntu-latest
     name: Test Image
-    needs: test-python-script
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,7 +38,6 @@ jobs:
   test-action:
     runs-on: ubuntu-latest
     name: Test Action
-    needs: test-docker-image
     outputs:
       new-release: ${{ steps.create-release.outputs.version-long != '' }}
     steps:
@@ -57,7 +55,10 @@ jobs:
   publish-docker-image:
     runs-on: ubuntu-latest
     name: Publish Image
-    needs: test-action
+    needs: 
+      - test-python-script
+      - test-docker-image
+      - test-action
     if: ${{ needs.test-action.outputs.new-release }}
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Remove the path condition from the release workflow. Now that `action-release-changelog` handles non-release commits we can always run the action
- Run all tests simultaneously before publishing image