### PR TITLE
fix: action will find the action script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.11 (2025-02-16)
+### Bug Fixes
+- The action will now correctly run the release script
+
 ## 0.0.10 (2025-02-13)
 ### Features
 - When there is no new version in the changelog, don't set the `version-long` and `version-short` outputs

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ outputs:
     description: "Link to the created release"
 runs:
   using: "docker"
-  image: "docker://outoforbitdev/action-release-changelog:build--52f71f9"
+  image: "docker://outoforbitdev/action-release-changelog:build--0bc4f77"
   args:
     - ${{ inputs.github-token }}
     - ${{ inputs.changelog-file }}

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -7,4 +7,4 @@ write_to_summary=$4
 dry_run=$5
 repository=$6
 
-python src/create_release.py $github_token $changelog_file $draft $write_to_summary $dry_run $repository
+python /src/create_release.py $github_token $changelog_file $draft $write_to_summary $dry_run $repository


### PR DESCRIPTION
## Summary

The action was failing to run the python script because `entrypoint.sh` was not running the python script as an absolute path.