### PR TITLE
ci: don't run docker publish on chore

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,7 @@ jobs:
       - test-python-script
       - test-docker-image
       - test-action
+    if: ${{ !contains(github.event.pull_request.labels.*.name, format('type{0} chore', ':')) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Update the CI pipeline not to publish a docker image when the pull request has the `type: chore` label.

### Checklist

- [x] Fill out all sections of this pull request description
- [x] Assign this pull request to yourself
- [x] Add the following labels to this pull request:
    - [x] `effort: *` to describe the amount of effort required to review this pull request
    - [x] `type: *` to describe the type of change introduced in this pull request
    - [x] `work: *` to describe the complexity of the changes introduced by this pull request
- [x] Add at least one issue closed by this pull request. (If this pull request does not close an issue, consider adding an issue first.)

## Testing

NA

## Issues

NA
